### PR TITLE
17 implement node sign in with firebase

### DIFF
--- a/bcnode-setup.txt
+++ b/bcnode-setup.txt
@@ -1,2 +1,2 @@
-PublicKey: ,
+PublicKey: 
 BlockchainAddress: 

--- a/src/network/firebase.ts
+++ b/src/network/firebase.ts
@@ -1,6 +1,13 @@
 import { initializeApp } from "firebase/app";
-import { getFirestore } from "firebase/firestore"
-
+import {
+  addDoc,
+  collection,
+  getDocs,
+  getFirestore,
+  query,
+  where,
+} from "firebase/firestore";
+import { promises as fs } from "fs";
 
 const firebaseConfig = {
   apiKey: "AIzaSyBSxYlyxAw_li09nCZmjuc3eCOlboKqc5U",
@@ -9,11 +16,79 @@ const firebaseConfig = {
   storageBucket: "bytechain-bc.firebasestorage.app",
   messagingSenderId: "462823593162",
   appId: "1:462823593162:web:12933a358b24b12f0fd033",
-  measurementId: "G-LPLMJYN6GJ"
+  measurementId: "G-LPLMJYN6GJ",
 };
 
 const app = initializeApp(firebaseConfig);
 const db = getFirestore(app);
 
-
 export { app, db };
+
+/**
+ *  @param filePath - The path to the bcnode setup.txt file.
+ */
+
+export async function loginNodeFromSetupFile(filePath: string): Promise<void> {
+  try {
+    const content = await fs.readFile(filePath, "utf-8");
+    const lines = content.split("\n");
+    let publicKey = "";
+    let blockchainAddress = "";
+
+    for (const line of lines) {
+      const parts = line.split(":");
+      if (parts.length >= 2) {
+        const key = parts[0].trim().toLowerCase();
+        const value = parts.slice(1).join(":").trim();
+        if (key === "publickey" || key === "public key") {
+          publicKey = value;
+        } else if (
+          key === "blockchainaddress" ||
+          key === "blockchain address"
+        ) {
+          blockchainAddress = value;
+        }
+      }
+    }
+
+    if (!publicKey || !blockchainAddress) {
+      console.error(
+        "Public key or blockchain address missing in the setup file."
+      );
+      return;
+    }
+
+    // checks if node is registered
+    const nodesRef = collection(db, "nodes"); // Reference to the "nodes" collection.
+    const q = query(
+      nodesRef,
+      where("blockchainAddress", "==", blockchainAddress)
+    );
+    const querySnapshot = await getDocs(q);
+
+    // login if registered
+    if (!querySnapshot.empty) {
+      console.log("Node already registered. Logging in...");
+      // Additional login tasks to be added here
+      return;
+    }
+
+    // If not register.
+    const newNode = {
+      publicKey,
+      blockchainAddress,
+      registeredAt: new Date().toISOString(),
+    };
+    const docRef = await addDoc(nodesRef, newNode);
+
+    console.log("Node registered successfully with ID:", docRef.id);
+  } catch (error) {
+    console.error("Error logging in node from setup file:", error);
+  }
+}
+
+loginNodeFromSetupFile("../../bcnode-setup.txt")
+  .then(() => console.log("Login process complete."))
+  .catch((error) =>
+    console.error("Login process encountered an error:", error)
+  );


### PR DESCRIPTION
Implemented node sign in with firebase
The bcnode-setup.txt format should be:

PublicKey: 
BlockchainAddress: 

No commas needed, the file seperates each entry based on newlines not commas.
Only 1 pair of publickey and blockchainaddress can be put in the file any more would create an error

"Publickey" and "blockchainaddress" can also be written as "public key" and "blockchain address" with a space in the middle as the code will handle it if it has no spaces or 1 space any more will result in error.

"Publickey" and "blockchainaddress" can also be written in any case as the code is made to be case-insentitive but the values of these will be case-sensitive and must be written exactly as they appear

There is a block in the code to handle login of nodes - It currently only prints to the console